### PR TITLE
Fix the incorrect big endian mips gcc pre-defined compiler macros

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -6,4 +6,4 @@ Thank you to all contributors:
 
 [HuangYeWuDeng](https://github.com/ihacklog)
 
-
+[qihongwei](https://github.com/joycechu)

--- a/ikcp.h
+++ b/ikcp.h
@@ -236,7 +236,7 @@ typedef struct IQUEUEHEAD iqueue_head;
     #ifndef IWORDS_BIG_ENDIAN
         #if defined(__hppa__) || \
             defined(__m68k__) || defined(mc68000) || defined(_M_M68K) || \
-            (defined(__MIPS__) && defined(__MISPEB__)) || \
+            (defined(__mips__) && defined(__MIPSEB__)) || \
             defined(__ppc__) || defined(__POWERPC__) || defined(_M_PPC) || \
             defined(__sparc__) || defined(__powerpc__) || \
             defined(__mc68000__) || defined(__s390x__) || defined(__s390__)


### PR DESCRIPTION
Fix the incorrect big endian mips gcc pre-defined compiler macros (like ar71xx) 