### PR TITLE
CMake: Add check for Libevent library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y libevent-dev
+
+    - name: Create build directory
+      run: mkdir build
+
+    - name: Run CMake
+      run: cd build && cmake ..
+
+    - name: Run Make
+      run: cd build && make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.6)
 
 project(xkcptun C)
+find_package(Libevent REQUIRED)
 
 set(src_xkcp_spy
 	xkcp_spy.c)
@@ -16,7 +17,7 @@ set(src_xkcp_server
 	xkcp_config.c
     json.c
 	xkcp_mon.c)
-	
+
 set(src_xkcp_client
 	tcp_proxy.c
 	xkcp_client.c


### PR DESCRIPTION

This commit updates `CMakeLists.txt` to use `find_package(Libevent REQUIRED)`.
This ensures that the CMake configuration process will fail with an error if the Libevent development library is not found in the build environment.

This commit introduces a GitHub Actions workflow that triggers on every push.
The workflow performs the following steps:
1. Checks out the code.
2. Installs libevent-dev dependency.
3. Creates a build directory.
4. Runs CMake to configure the build.
5. Runs make to compile the project.

This will help ensure that all your commits result in a successful build.