### PR TITLE
Fix CMake configuration to correctly find Libevent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 project(xkcptun C)
-find_package(Libevent REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_search_module(Libevent REQUIRED libevent)
+include_directories(${Libevent_INCLUDE_DIRS})
 
 set(src_xkcp_spy
 	xkcp_spy.c)
@@ -32,7 +34,7 @@ set(src_xkcp_client
 
 set(libs
     m
-	event)
+	${Libevent_LIBRARIES})
 
 ADD_DEFINITIONS(-Wall -O2 --std=gnu99 -Wmissing-declarations)
 


### PR DESCRIPTION
This commit addresses two issues in the CMake configuration:

1.  Updated the minimum required CMake version from 2.6 to 3.10. This resolves a CMake deprecation warning.
2.  Modified `CMakeLists.txt` to use `pkg-config` for finding the Libevent library. This resolves an error where CMake could not find the Libevent package configuration files.

The GitHub Actions build was failing due to the Libevent discovery issue. With these changes, the build process (both CMake configuration and compilation with Make) now completes successfully.