### PR TITLE
I've resolved the strict-aliasing warnings in `json.c` by modifying p…

### DIFF
--- a/json.c
+++ b/json.c
@@ -143,7 +143,8 @@ static int new_value (json_state * state,
                return 0;
             }
 
-            value->_reserved.object_mem = (*(char **) &value->u.object.values) + values_size;
+            char *temp_ptr = (char *)value->u.object.values;
+            value->_reserved.object_mem = temp_ptr + values_size;
 
             value->u.object.length = 0;
             break;
@@ -405,7 +406,11 @@ json_value * json_parse_ex (json_settings * settings,
                   case json_object:
 
                      if (state.first_pass)
-                        (*(json_char **) &top->u.object.values) += string_length + 1;
+                     {
+                        json_char *temp_ptr = (json_char *)top->u.object.values;
+                        temp_ptr += string_length + 1;
+                        top->u.object.values = (json_object_entry *)temp_ptr;
+                     }
                      else
                      {  
                         top->u.object.values [top->u.object.length].name


### PR DESCRIPTION
…ointer casting and dereferencing.

The warnings occurred at two locations:
1. `json.c:146`: I changed `value->_reserved.object_mem = (*(char **) &value->u.object.values) + values_size;` to use a temporary `char*` variable, avoiding the direct type-punned dereference.
2. `json.c:408`: I changed `(*(json_char **) &top->u.object.values) += string_length + 1;` to use a temporary `json_char*` variable and then assign back to `top->u.object.values`, thus preventing the problematic dereference.

These changes ensure safer pointer manipulation and eliminate the compiler warnings. Compilation was successful, and no regressions were observed.